### PR TITLE
fixed image url for xkcd and explosm

### DIFF
--- a/comics.py
+++ b/comics.py
@@ -63,7 +63,7 @@ def getcomic():
 		try:
 			page = urllib2.urlopen(url)
 			soup = BeautifulSoup(page)
-			img = soup.find('div',{'id':'comic'}).find('img')['src']
+			img = "http:" + soup.find('div',{'id':'comic'}).find('img')['src']
 			res = urllib2.urlopen(img)
 			output = open(os.path.join(APP_IMAGES, 'xkcd.png'), 'wb')
 			output.write(res.read())
@@ -78,7 +78,7 @@ def getcomic():
 		try:
 			page = urllib2.urlopen(url)
 			soup = BeautifulSoup(page)
-			img = soup.find('div',{'id':'maincontent'}).findAll('img')[5]['src']
+			img = "http:" + soup.find('img',{'id':'main-comic'})['src']
 			print img
 			res = urllib2.urlopen(img)
 			output = open(os.path.join(APP_IMAGES, 'explosm.png'), 'wb')


### PR DESCRIPTION
Basically xkcd and explosm have changed the image url and removed http from it. So to compensate for that i have added the same to the url string.
